### PR TITLE
Dont fail if config-file is not provided

### DIFF
--- a/graphite/client.go
+++ b/graphite/client.go
@@ -56,9 +56,13 @@ type Client struct {
 // NewClient creates a new Client.
 func NewClient(carbon string, carbon_transport string, write_timeout time.Duration,
 	graphite_web string, read_timeout time.Duration, prefix string, configFile string) *Client {
-	fileConf, err := config.LoadFile(configFile)
-	if err != nil {
-		log.With("err", err).Warnln("Error loading config file")
+	fileConf := &config.Config{}
+	if configFile != "" {
+		var err error
+		fileConf, err = config.LoadFile(configFile)
+		if err != nil {
+			log.With("err", err).Warnln("Error loading config file")
+		}
 	}
 	return &Client{
 		carbon:           carbon,

--- a/main.go
+++ b/main.go
@@ -101,8 +101,8 @@ func parseFlags() *config {
 	log.Infoln("Parsing flags")
 	cfg := &config{}
 
-	flag.StringVar(&cfg.configFile, "config-file", "graphite-remote-adapter.yml",
-		"Graphite remote adapter configuration file name.",
+	flag.StringVar(&cfg.configFile, "config-file", "",
+		"Graphite remote adapter configuration file name. None, if empty.",
 	)
 	flag.StringVar(&cfg.carbonAddress, "carbon-address", "",
 		"The host:port of the Graphite server to send samples to. None, if empty.",


### PR DESCRIPTION
Config file is not mandatory to run the graphite-remote-adapter, so it should not have a default value.
Indeed if the default config-file doesn't exist it fails to start even if it's not needed.
Now it fail only if the config-file flag is provided and the provided filename doesn't exist.