### PR TITLE
client: quit if we fail to read config file

### DIFF
--- a/graphite/client.go
+++ b/graphite/client.go
@@ -62,6 +62,7 @@ func NewClient(carbon string, carbon_transport string, write_timeout time.Durati
 		fileConf, err = config.LoadFile(configFile)
 		if err != nil {
 			log.With("err", err).Warnln("Error loading config file")
+			return nil
 		}
 	}
 	return &Client{

--- a/main.go
+++ b/main.go
@@ -93,7 +93,11 @@ func main() {
 	http.Handle(cfg.telemetryPath, prometheus.Handler())
 
 	writers, readers := buildClients(cfg)
-	serve(cfg.listenAddr, writers, readers)
+	if len(writers) != 0 || len(readers) != 0 {
+		serve(cfg.listenAddr, writers, readers)
+	} else {
+		log.Warnln("No reader nor writer, leaving")
+	}
 	log.Infoln("See you next time!")
 }
 
@@ -149,8 +153,10 @@ func buildClients(cfg *config) ([]writer, []reader) {
 			cfg.carbonAddress, cfg.carbonTransport, cfg.remoteWriteTimeout,
 			cfg.graphiteWebURL, cfg.remoteReadTimeout,
 			cfg.graphitePrefix, cfg.configFile)
-		writers = append(writers, c)
-		readers = append(readers, c)
+		if c != nil {
+			writers = append(writers, c)
+			readers = append(readers, c)
+		}
 	}
 	log.With("num_writers", len(writers)).With("num_readers", len(readers)).Infof("Built clients")
 	return writers, readers


### PR DESCRIPTION
this fixes a segfault when trying to access fileConf attributes later

WARN[0000] Error loading config file                     err="open add: no such file or directory" source="client.go:64"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x88821d]
goroutine 1 [running]:
graphite.NewClient(0x7ffd5cdbeaa3, 0x2a, 0x7ffd5cdbeae0, 0x3, 0x12a05f200, 0x7ffd5cdbea72, 0x20, 0x6fc23ac00, 0x7ffd5cdbeb18, 0x1b, ...)
        graphite/client.go:75 +0x18d
main.buildClients(0xc42015c780, 0x8, 0xc11ee0, 0xc42013f8b0, 0x1b, 0x9acde0, 0x3a)
        main.go:151 +0x125
main.main()
        main.go:95 +0x26c
exit status 2