### PR TITLE
Fix loadContext concurrent map read and map write

### DIFF
--- a/graphite/rules.go
+++ b/graphite/rules.go
@@ -28,15 +28,16 @@ import (
 )
 
 func loadContext(template_data map[string]interface{}, m model.Metric) map[string]interface{} {
-	if template_data == nil {
-		template_data = make(map[string]interface{})
+	ctx := make(map[string]interface{})
+	for k, v := range template_data {
+		ctx[k] = v
 	}
 	labels := make(map[string]string)
 	for ln, lv := range m {
 		labels[string(ln)] = string(lv)
 	}
-	template_data["labels"] = labels
-	return template_data
+	ctx["labels"] = labels
+	return ctx
 }
 
 func match(m model.Metric, match config.LabelSet, matchRE config.LabelSetRE) bool {


### PR DESCRIPTION
  - When using the 'template_data' directive 'concurrent map read
    and map write' error occur (under a moderate to heavy load)
    within the loadContext function.
  - This due to the fact that the template_data map can be
    modified concurrently by more than one goroutine.
  - To fix this, we use, within the loadContext function, a
    newly created a map that is populated with the content of
    the template_data map; this avoid concurrent modifications

Signed-off-by: Jean-Francois Weber-Marx <jfwm@hotmail.com>