### PR TITLE
graphite: add a way to periodically reset the carbon connection

### DIFF
--- a/client/graphite/config/config.go
+++ b/client/graphite/config/config.go
@@ -33,6 +33,7 @@ var DefaultConfig = Config{
 	Write: WriteConfig{
 		CarbonAddress:           "",
 		CarbonTransport:         "tcp",
+		CarbonReconnectInterval: 1 * time.Hour,
 		EnablePathsCache:        true,
 		PathsCacheTTL:           1 * time.Hour,
 		PathsCachePurgeInterval: 2 * time.Hour,
@@ -92,6 +93,7 @@ func (c *ReadConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type WriteConfig struct {
 	CarbonAddress           string                 `yaml:"carbon_address,omitempty" json:"carbon_address,omitempty"`
 	CarbonTransport         string                 `yaml:"carbon_transport,omitempty" json:"carbon_transport,omitempty"`
+	CarbonReconnectInterval time.Duration          `yaml:"carbon_reconnect_interval,omitempty" json:"carbon_reconnect_interval,omitempty"`
 	EnablePathsCache        bool                   `yaml:"enable_paths_cache,omitempty" json:"enable_paths_cache,omitempty"`
 	PathsCacheTTL           time.Duration          `yaml:"paths_cache_ttl,omitempty" json:"paths_cache_ttl,omitempty"`
 	PathsCachePurgeInterval time.Duration          `yaml:"paths_cache_purge_interval,omitempty" json:"paths_cache_purge_interval,omitempty"`

--- a/client/graphite/config/config_test.go
+++ b/client/graphite/config/config_test.go
@@ -35,6 +35,7 @@ var (
 			CarbonAddress:           "greatCarbonAddress",
 			CarbonTransport:         "tcp",
 			EnablePathsCache:        true,
+			CarbonReconnectInterval: 2 * time.Minute,
 			PathsCacheTTL:           18 * time.Minute,
 			PathsCachePurgeInterval: 42 * time.Minute,
 			TemplateData: map[string]interface{}{

--- a/client/graphite/config/testdata/graphite.good.yml
+++ b/client/graphite/config/testdata/graphite.good.yml
@@ -4,6 +4,7 @@ read:
 write:
   carbon_address: greatCarbonAddress
   carbon_transport: tcp
+  carbon_reconnect_interval: 2m
   enable_paths_cache: true
   paths_cache_ttl: 18m
   paths_cache_purge_interval: 42m

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -22,6 +22,7 @@ import (
 type Client interface {
 	Name() string
 	String() string
+	Shutdown()
 }
 
 // Writer is a client taht sends a batch of samples to remote.

--- a/main.go
+++ b/main.go
@@ -202,6 +202,13 @@ func (s *Server) ReloadConfig(logger log.Logger, cfg *config.Config) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
+	for _, v := range s.writers {
+		v.Shutdown()
+	}
+	for _, v := range s.readers {
+		v.Shutdown()
+	}
+
 	s.cfg = cfg
 	s.writers, s.readers = buildClients(cfg, logger)
 


### PR DESCRIPTION
This is important when using UDP because you might not notice
that the host has now moved to another IP. This way the DNS gets
re-resolved and the connection reset to where it should be. Using
TCP here might not always be doable. This can be disabled by
setting a very large duration but should never hurt.

See #23 and https://github.com/prometheus/prometheus/pull/3635