### PR TITLE
Support for Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ read:
   ignore_error: true
 graphite:
   default_prefix: test.prefix.
+  enable_tags: false
   read:
     url: http://localhost:8888
   write:
@@ -95,6 +96,12 @@ graphite:
       continue: false
 
 ```
+
+## Support for Tags
+
+Graphite 1.1.0 supports tags: http://graphite.readthedocs.io/en/latest/tags.html, you can
+enable support for tags in the remote adapter with `--graphite.enable-tags` or in the
+configuration file.
 
 ## Configuring Prometheus
 

--- a/client/graphite/config/cli.go
+++ b/client/graphite/config/cli.go
@@ -33,4 +33,8 @@ func AddCommandLine(app *kingpin.Application, cfg *Config) {
 	app.Flag("graphite.write.paths-cache-purge-interval",
 		"Duration between purges for expired items in the paths cache.").
 		DurationVar(&cfg.Write.PathsCachePurgeInterval)
+
+	app.Flag("graphite.enable-tags",
+		"Use Graphite tags.").
+		BoolVar(&cfg.EnableTags)
 }

--- a/client/graphite/config/config.go
+++ b/client/graphite/config/config.go
@@ -29,7 +29,9 @@ import (
 
 // DefaultConfig is the default graphite configuration.
 var DefaultConfig = Config{
-	DefaultPrefix: "",
+	DefaultPrefix:        "",
+	EnableTags:           false,
+	UseOpenMetricsFormat: false,
 	Write: WriteConfig{
 		CarbonAddress:           "",
 		CarbonTransport:         "tcp",
@@ -45,9 +47,11 @@ var DefaultConfig = Config{
 
 // Config is the graphite configuration.
 type Config struct {
-	Write         WriteConfig `yaml:"write,omitempty" json:"write,omitempty"`
-	Read          ReadConfig  `yaml:"read,omitempty" json:"read,omitempty"`
-	DefaultPrefix string      `yaml:"default_prefix,omitempty" json:"default_prefix,omitempty"`
+	Write                WriteConfig `yaml:"write,omitempty" json:"write,omitempty"`
+	Read                 ReadConfig  `yaml:"read,omitempty" json:"read,omitempty"`
+	DefaultPrefix        string      `yaml:"default_prefix,omitempty" json:"default_prefix,omitempty"`
+	EnableTags           bool        `yaml:"enable_tags,omitempty" json:"enable_tags,omitempty"`
+	UseOpenMetricsFormat bool        `yaml:"openmetrics,omitempty" json:"openmetrics,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`

--- a/client/graphite/config/config_test.go
+++ b/client/graphite/config/config_test.go
@@ -27,7 +27,9 @@ import (
 
 var (
 	expectedConf = &Config{
-		DefaultPrefix: "test.prefix.",
+		DefaultPrefix:        "test.prefix.",
+		EnableTags:           true,
+		UseOpenMetricsFormat: true,
 		Read: ReadConfig{
 			URL: "greatGraphiteWebURL",
 		},

--- a/client/graphite/config/testdata/graphite.good.yml
+++ b/client/graphite/config/testdata/graphite.good.yml
@@ -1,4 +1,6 @@
 default_prefix: test.prefix.
+enable_tags: true
+openmetrics: true
 read:
   url: greatGraphiteWebURL
 write:

--- a/client/graphite/http.go
+++ b/client/graphite/http.go
@@ -34,6 +34,7 @@ type ExpandResponse struct {
 type RenderResponse struct {
 	Target     string       `yaml:"target,omitempty" json:"target,omitempty"`
 	Datapoints []*Datapoint `yaml:"datapoints,omitempty" json:"datapoints,omitempty"`
+	Tags       Tags         `yaml:"tags,omitempty" json:"tags,omitempty"`
 }
 
 // Datapoint pairs a timestamp to a value.
@@ -41,6 +42,9 @@ type Datapoint struct {
 	Value     *float64
 	Timestamp int64
 }
+
+// Tags
+type Tags map[string]string
 
 // UnmarshalJSON unmarshals a Datapoint from json
 func (d *Datapoint) UnmarshalJSON(b []byte) error {

--- a/client/graphite/write.go
+++ b/client/graphite/write.go
@@ -83,7 +83,7 @@ func (c *Client) Write(samples model.Samples) error {
 
 	var buf bytes.Buffer
 	for _, s := range samples {
-		paths := pathsFromMetric(s.Metric, c.cfg.DefaultPrefix, c.cfg.Write.Rules, c.cfg.Write.TemplateData)
+		paths := pathsFromMetric(s.Metric, c.format, c.cfg.DefaultPrefix, c.cfg.Write.Rules, c.cfg.Write.TemplateData)
 		for _, k := range paths {
 			if str := c.prepareDataPoint(k, s); str != "" {
 				fmt.Fprint(&buf, str)

--- a/main.go
+++ b/main.go
@@ -387,6 +387,8 @@ func (s *Server) read(logger log.Logger, w http.ResponseWriter, r *http.Request)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+	}
+	if resp == nil {
 		resp = &prompb.ReadResponse{
 			Results: []*prompb.QueryResult{
 				{Timeseries: make([]*prompb.TimeSeries, 0, 0)},


### PR DESCRIPTION
Write:
- Support tags, in carbon and openmetrics format

Read:
- Support tags

TODO in a later patch:
- Support Graphite native Prometheus support: graphite-project/graphite-web#2195
- Support for upcomming Carbon native Prometheus support: graphite-project/carbon#735
- For both of these, just make sure the prefix is handled correctly.

Some of this code comes from https://github.com/prometheus/prometheus/pull/3533/files