### PR TITLE
graphite: fix read with golang 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: go
 
 go:
-- 1.8.x
+- 1.9.x
 
 go_import_path: github.com/criteo/graphite-remote-adapter
 


### PR DESCRIPTION
I honestly don't know how it worked before.

Now we use a nil result to mark the work as done as
soon as all workers have terminated.