### PR TITLE
Add the possibility to use a custom graphite prefix

### DIFF
--- a/client/graphite/client.go
+++ b/client/graphite/client.go
@@ -15,6 +15,9 @@
 package graphite
 
 import (
+	"net"
+	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -25,7 +28,6 @@ import (
 
 	graphiteCfg "github.com/criteo/graphite-remote-adapter/client/graphite/config"
 	"github.com/criteo/graphite-remote-adapter/config"
-	"net"
 )
 
 const (
@@ -110,4 +112,17 @@ func (c *Client) Name() string {
 func (c *Client) String() string {
 	// TODO: add more stuff here.
 	return c.cfg.String()
+}
+
+// Get graphite prefix
+func (c *Client) getGraphitePrefix(r *http.Request) (string, error) {
+	urlValues, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		return "", err
+	}
+
+	if graphitePrefix, ok := urlValues["graphite.default-prefix"]; ok {
+		return graphitePrefix[0], nil
+	}
+	return c.cfg.DefaultPrefix, nil
 }

--- a/client/graphite/client_test.go
+++ b/client/graphite/client_test.go
@@ -1,0 +1,56 @@
+// Copyright 2017 Thibault Chataigner <thibault.chataigner@gmail.com>
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graphite
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/criteo/graphite-remote-adapter/client/graphite/config"
+	"github.com/go-kit/kit/log"
+)
+
+var (
+	testClient = &Client{
+		logger: log.NewNopLogger(),
+		cfg: &config.Config{
+			DefaultPrefix: "prometheus-prefix.",
+			Write:         config.WriteConfig{},
+			Read: config.ReadConfig{
+				URL: "http://fakeHost:6666",
+			},
+		},
+	}
+)
+
+func TestGetGraphitePrefix(t *testing.T) {
+	fakeRequest, _ := http.NewRequest("POST", "http://fakeHost:6666", nil)
+	expectedPrefix := testClient.cfg.DefaultPrefix
+
+	actualPrefix, _ := testClient.getGraphitePrefix(fakeRequest)
+	if !reflect.DeepEqual(expectedPrefix, actualPrefix) {
+		t.Errorf("Expected %s, got %s", expectedPrefix, actualPrefix)
+	}
+}
+
+func TestGetCustomGraphitePrefix(t *testing.T) {
+	fakeRequest, _ := http.NewRequest("POST", "http://fakeHost:6666?graphite.default-prefix=foo.bar.custom.", nil)
+	expectedPrefix := "foo.bar.custom."
+
+	actualPrefix, _ := testClient.getGraphitePrefix(fakeRequest)
+	if !reflect.DeepEqual(expectedPrefix, actualPrefix) {
+		t.Errorf("Expected %s, got %s", expectedPrefix, actualPrefix)
+	}
+}

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -14,6 +14,8 @@
 package client
 
 import (
+	"net/http"
+
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 )
@@ -27,12 +29,12 @@ type Client interface {
 
 // Writer is a client taht sends a batch of samples to remote.
 type Writer interface {
-	Write(samples model.Samples) error
+	Write(samples model.Samples, r *http.Request) error
 	Client
 }
 
 // Reader is a client that read samples from remote.
 type Reader interface {
-	Read(req *prompb.ReadRequest) (*prompb.ReadResponse, error)
+	Read(req *prompb.ReadRequest, r *http.Request) (*prompb.ReadResponse, error)
 	Client
 }


### PR DESCRIPTION
The goal of this PR is to use as a custom prefix from
the remote_write and remote_read URL.

Basically the graphite path will be set like that in
the Prometheus configuration:

remote_write:
  - url: "http://localhost:9201/write?graphite.default-prefix=customprefix."

remote_read:
  - url: "http://localhost:9201/read?graphite.default-prefix=customprefix."

If this custom prefix is set, then the default prefix will not be
used.