### PR TITLE
Add Namespace to applicative metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Metrics namespace
 
 ## [0.0.15] - 2018-02-28
 ### Added

--- a/client/graphite/client.go
+++ b/client/graphite/client.go
@@ -86,8 +86,9 @@ func NewClient(cfg *config.Config, logger log.Logger) *Client {
 		readDelay:    cfg.Read.Delay,
 		ignoredSamples: prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "prometheus_graphite_ignored_samples_total",
-				Help: "The total number of samples not sent to Graphite due to unsupported float values (Inf, -Inf, NaN).",
+				Namespace: "remote_adapter_graphite",
+				Name:      "ignored_samples_total",
+				Help:      "The total number of samples not sent to Graphite due to unsupported float values (Inf, -Inf, NaN).",
 			},
 		),
 		carbonCon:               nil,

--- a/main.go
+++ b/main.go
@@ -43,32 +43,39 @@ import (
 	"github.com/criteo/graphite-remote-adapter/config"
 )
 
+// Constants for instrumentation.
+const namespace = "remote_adapter"
+
 var (
 	receivedSamples = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "received_samples_total",
-			Help: "Total number of received samples.",
+			Namespace: namespace,
+			Name:      "received_samples_total",
+			Help:      "Total number of received samples.",
 		},
 	)
 	sentSamples = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "sent_samples_total",
-			Help: "Total number of processed samples sent to remote storage.",
+			Namespace: namespace,
+			Name:      "sent_samples_total",
+			Help:      "Total number of processed samples sent to remote storage.",
 		},
 		[]string{"remote"},
 	)
 	failedSamples = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "failed_samples_total",
-			Help: "Total number of processed samples which failed on send to remote storage.",
+			Namespace: namespace,
+			Name:      "failed_samples_total",
+			Help:      "Total number of processed samples which failed on send to remote storage.",
 		},
 		[]string{"remote"},
 	)
 	sentBatchDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "sent_batch_duration_seconds",
-			Help:    "Duration of sample batch send calls to the remote storage.",
-			Buckets: prometheus.DefBuckets,
+			Namespace: namespace,
+			Name:      "sent_batch_duration_seconds",
+			Help:      "Duration of sample batch send calls to the remote storage.",
+			Buckets:   prometheus.DefBuckets,
 		},
 		[]string{"remote"},
 	)


### PR DESCRIPTION
This way we can identify/select them when scraping remote adapter instances

cc @iksaif 