### PR TITLE
Handle template replace errors

### DIFF
--- a/client/graphite/rules.go
+++ b/client/graphite/rules.go
@@ -108,6 +108,7 @@ func templatedPaths(m model.Metric, rules []*config.Rule, templateData map[strin
 		}
 
 		context := loadContext(templateData, m)
+		stop = !rule.Continue
 		var path bytes.Buffer
 		err = rule.Tmpl.Execute(&path, context)
 		if err != nil {
@@ -116,7 +117,6 @@ func templatedPaths(m model.Metric, rules []*config.Rule, templateData map[strin
 		}
 		paths = append(paths, path.String())
 
-		stop = !rule.Continue
 		if rule.Continue == false {
 			break
 		}

--- a/client/graphite/rules.go
+++ b/client/graphite/rules.go
@@ -107,8 +107,12 @@ func templatedPaths(m model.Metric, rules []*config.Rule, templateData map[strin
 
 		context := loadContext(templateData, m)
 		var path bytes.Buffer
-		rule.Tmpl.Execute(&path, context)
-		paths = append(paths, path.String())
+		err := rule.Tmpl.Execute(&path, context)
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			paths = append(paths, path.String())
+		}
 
 		stop = !rule.Continue
 		if rule.Continue == false {

--- a/client/graphite/rules_test.go
+++ b/client/graphite/rules_test.go
@@ -79,8 +79,9 @@ func TestDefaultPathsFromMetric(t *testing.T) {
 		".many_chars.abc!ABC:012-3!45%C3%B667~89%2E%2F\\(\\)\\{\\}\\,%3D%2E\\\"\\\\" +
 		".owner.team-X" +
 		".testlabel.test:value"
-	actual := pathsFromMetric(metric, FormatCarbon, "prefix.", nil, nil)
+	actual, err := pathsFromMetric(metric, FormatCarbon, "prefix.", nil, nil)
 	require.Equal(t, expected, actual[0])
+	require.Empty(t, err)
 
 	expected = "prefix." +
 		"test:metric" +
@@ -88,8 +89,9 @@ func TestDefaultPathsFromMetric(t *testing.T) {
 		";owner=team-X" +
 		";testlabel=test:value"
 
-	actual = pathsFromMetric(metric, FormatCarbonTags, "prefix.", nil, nil)
+	actual, err = pathsFromMetric(metric, FormatCarbonTags, "prefix.", nil, nil)
 	require.Equal(t, expected, actual[0])
+	require.Empty(t, err)
 
 	expected = "prefix." +
 		"test:metric{" +
@@ -97,8 +99,9 @@ func TestDefaultPathsFromMetric(t *testing.T) {
 		",owner=\"team-X\"" +
 		",testlabel=\"test:value\"" +
 		"}"
-	actual = pathsFromMetric(metric, FormatCarbonOpenMetrics, "prefix.", nil, nil)
+	actual, err = pathsFromMetric(metric, FormatCarbonOpenMetrics, "prefix.", nil, nil)
 	require.Equal(t, expected, actual[0])
+	require.Empty(t, err)
 }
 
 func TestUnmatchedMetricPathsFromMetric(t *testing.T) {
@@ -114,15 +117,17 @@ func TestUnmatchedMetricPathsFromMetric(t *testing.T) {
 		".owner.team-K"+
 		".testlabel.test:value"+
 		".testlabel2.test:value2")
-	actual := pathsFromMetric(unmatchedMetric, FormatCarbon, "prefix.", testConfig.Write.Rules, testConfig.Write.TemplateData)
+	actual, err := pathsFromMetric(unmatchedMetric, FormatCarbon, "prefix.", testConfig.Write.Rules, testConfig.Write.TemplateData)
 	require.Equal(t, expected, actual)
+	require.Empty(t, err)
 }
 
 func TestTemplatedPathsFromMetric(t *testing.T) {
 	expected := make([]string, 0)
 	expected = append(expected, "tmpl_3.team-Y.data.foo")
-	actual := pathsFromMetric(metricY, FormatCarbon, "", testConfig.Write.Rules, testConfig.Write.TemplateData)
+	actual, err := pathsFromMetric(metricY, FormatCarbon, "", testConfig.Write.Rules, testConfig.Write.TemplateData)
 	require.Equal(t, expected, actual)
+	require.Empty(t, err)
 }
 
 func TestTemplatedPathsFromMetricWithDefault(t *testing.T) {
@@ -133,8 +138,9 @@ func TestTemplatedPathsFromMetricWithDefault(t *testing.T) {
 		".many_chars.abc!ABC:012-3!45%C3%B667~89%2E%2F\\(\\)\\{\\}\\,%3D%2E\\\"\\\\"+
 		".owner.team-X"+
 		".testlabel.test:value")
-	actual := pathsFromMetric(metric, FormatCarbon, "prefix.", testConfig.Write.Rules, testConfig.Write.TemplateData)
+	actual, err := pathsFromMetric(metric, FormatCarbon, "prefix.", testConfig.Write.Rules, testConfig.Write.TemplateData)
 	require.Equal(t, expected, actual)
+	require.Empty(t, err)
 }
 
 func TestMultiTemplatedPathsFromMetric(t *testing.T) {
@@ -147,8 +153,9 @@ func TestMultiTemplatedPathsFromMetric(t *testing.T) {
 	expected := make([]string, 0)
 	expected = append(expected, "tmpl_1.data%2Efoo.team-X")
 	expected = append(expected, "tmpl_2.team-X.data.foo")
-	actual := pathsFromMetric(multiMatchMetric, FormatCarbon, "prefix.", testConfig.Write.Rules, testConfig.Write.TemplateData)
+	actual, err := pathsFromMetric(multiMatchMetric, FormatCarbon, "prefix.", testConfig.Write.Rules, testConfig.Write.TemplateData)
 	require.Equal(t, expected, actual)
+	require.Empty(t, err)
 }
 
 func TestSkipedTemplatedPathsFromMetric(t *testing.T) {
@@ -159,8 +166,9 @@ func TestSkipedTemplatedPathsFromMetric(t *testing.T) {
 		"testlabel2":          "test:value2",
 	}
 	t.Log(testConfig.Write.Rules[2])
-	actual := pathsFromMetric(skipedMetric, FormatCarbon, "", testConfig.Write.Rules, testConfig.Write.TemplateData)
+	actual, err := pathsFromMetric(skipedMetric, FormatCarbon, "", testConfig.Write.Rules, testConfig.Write.TemplateData)
 	require.Empty(t, actual)
+	require.Empty(t, err)
 }
 
 func TestMetricLabelsFromPath(t *testing.T) {

--- a/client/graphite/rules_test.go
+++ b/client/graphite/rules_test.go
@@ -181,3 +181,20 @@ func TestMetricLabelsFromPath(t *testing.T) {
 	actualLabels, _ := metricLabelsFromPath(path, prefix)
 	require.Equal(t, expectedLabels, actualLabels)
 }
+
+func TestReplaceNilLabelTemplatedPathsFromMetric(t *testing.T) {
+	testConfigNilLabelStr := `
+write:
+  rules:
+  - match_re:
+      testlabel: test:value
+    template: 'test.{{ replace .labels.doesnotexist " " "_" }}'
+    continue: false`
+
+	testConfigNilLabel := loadTestConfig(testConfigNilLabelStr)
+
+	t.Log(testConfigNilLabel.Write.Rules[0])
+	actual, err := pathsFromMetric(metric, FormatCarbon, "", testConfigNilLabel.Write.Rules, testConfigNilLabel.Write.TemplateData)
+	require.Empty(t, actual)
+	require.Error(t, err)
+}

--- a/client/graphite/write.go
+++ b/client/graphite/write.go
@@ -90,7 +90,10 @@ func (c *Client) Write(samples model.Samples, r *http.Request) error {
 
 	var buf bytes.Buffer
 	for _, s := range samples {
-		paths := pathsFromMetric(s.Metric, c.format, graphitePrefix, c.cfg.Write.Rules, c.cfg.Write.TemplateData)
+		paths, err := pathsFromMetric(s.Metric, c.format, graphitePrefix, c.cfg.Write.Rules, c.cfg.Write.TemplateData)
+		if err != nil {
+			level.Warn(c.logger).Log("sample", s, "err", err)
+		}
 		for _, k := range paths {
 			if str := c.prepareDataPoint(k, s); str != "" {
 				fmt.Fprint(&buf, str)

--- a/utils/template.go
+++ b/utils/template.go
@@ -14,14 +14,14 @@
 package utils
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 	"text/template"
 )
 
 func replace(input interface{}, from string, to string) (string, error) {
 	if input == nil {
-		return "", fmt.Errorf("input does not exist, cannot replace")
+		return "", errors.New("input does not exist, cannot replace")
 	}
 	return strings.Replace(input.(string), from, to, -1), nil
 }

--- a/utils/template.go
+++ b/utils/template.go
@@ -14,12 +14,16 @@
 package utils
 
 import (
+	"fmt"
 	"strings"
 	"text/template"
 )
 
-func replace(input interface{}, from string, to string) string {
-	return strings.Replace(input.(string), from, to, -1)
+func replace(input interface{}, from string, to string) (string, error) {
+	if input == nil {
+		return "", fmt.Errorf("input does not exist, cannot replace")
+	}
+	return strings.Replace(input.(string), from, to, -1), nil
 }
 
 func split(input interface{}, delimiter string) ([]string, error) {


### PR DESCRIPTION
Prevent graphite-remote-adpater from crashing when trying to replace a label that does not exist (nil to string conversion does not go well).