### PR TITLE
Fix test error

### DIFF
--- a/client/graphite/read_test.go
+++ b/client/graphite/read_test.go
@@ -110,7 +110,7 @@ func TestTargetToTimeseries(t *testing.T) {
 
 	actualTs, err := testClient.targetToTimeseries(nil, "prometheus-prefix.test.owner.team-X", "0", "300", testClient.cfg.DefaultPrefix)
 	if !reflect.DeepEqual(err, nil) {
-		t.Errorf("Expected err: %s, got %s", nil, err)
+		t.Errorf("Expected no err, got %s", err)
 	}
 	if !reflect.DeepEqual(expectedTs, actualTs[0]) {
 		t.Errorf("Expected %s, got %s", expectedTs, actualTs[0])


### PR DESCRIPTION
Hello,

make test failed using go version go1.10.2 linux/amd64) :
```
client/graphite/read_test.go:113: Errorf format %s has arg nil of wrong type untyped nil
FAIL	github.com/criteo/graphite-remote-adapter/client/graphite [build failed]
```