### PR TITLE
Unescape

### DIFF
--- a/client/graphite/read.go
+++ b/client/graphite/read.go
@@ -32,8 +32,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-var unescape bool
-
 func (c *Client) queryToTargets(ctx context.Context, query *prompb.Query, graphitePrefix string) ([]string, error) {
 	// Parse metric name from query
 	var name string
@@ -117,7 +115,7 @@ func (c *Client) filterTargets(query *prompb.Query, targets []string, graphitePr
 	var results []string
 	for _, target := range targets {
 		// Put labels in a map.
-		labels, err := metricLabelsFromPath(target, graphitePrefix, unescape)
+		labels, err := metricLabelsFromPath(target, graphitePrefix)
 		if err != nil {
 			level.Warn(c.logger).Log(
 				"path", target, "prefix", graphitePrefix, "err", err)
@@ -188,7 +186,7 @@ func (c *Client) targetToTimeseries(ctx context.Context, target string, from str
 		if c.cfg.EnableTags {
 			ts.Labels, err = metricLabelsFromTags(renderResponse.Tags, graphitePrefix)
 		} else {
-			ts.Labels, err = metricLabelsFromPath(renderResponse.Target, graphitePrefix, unescape)
+			ts.Labels, err = metricLabelsFromPath(renderResponse.Target, graphitePrefix)
 		}
 
 		if err != nil {
@@ -353,10 +351,6 @@ func (c *Client) Read(req *prompb.ReadRequest, r *http.Request) (*prompb.ReadRes
 
 	ctx, cancel := context.WithTimeout(context.Background(), c.readTimeout)
 	defer cancel()
-
-	params := r.URL.Query()
-	// unescape will be true if there is a param named 'unescape' in the URL request
-	_, unescape = params["unescape"]
 
 	graphitePrefix, err := c.getGraphitePrefix(r)
 	if err != nil {

--- a/client/graphite/rules.go
+++ b/client/graphite/rules.go
@@ -202,7 +202,7 @@ func metricLabelsFromTags(tags Tags, prefix string) ([]*prompb.Label, error) {
 	return labels, nil
 }
 
-func metricLabelsFromPath(path string, prefix string, unescape bool) ([]*prompb.Label, error) {
+func metricLabelsFromPath(path string, prefix string) ([]*prompb.Label, error) {
 	// It uses the "default" write format to read back (See defaultPath function)
 	// <prefix.><__name__.>[<labelName>.<labelValue>. for each label in alphabetic order]
 	var labels []*prompb.Label

--- a/client/graphite/rules.go
+++ b/client/graphite/rules.go
@@ -202,7 +202,7 @@ func metricLabelsFromTags(tags Tags, prefix string) ([]*prompb.Label, error) {
 	return labels, nil
 }
 
-func metricLabelsFromPath(path string, prefix string) ([]*prompb.Label, error) {
+func metricLabelsFromPath(path string, prefix string, unescape bool) ([]*prompb.Label, error) {
 	// It uses the "default" write format to read back (See defaultPath function)
 	// <prefix.><__name__.>[<labelName>.<labelValue>. for each label in alphabetic order]
 	var labels []*prompb.Label
@@ -215,7 +215,7 @@ func metricLabelsFromPath(path string, prefix string) ([]*prompb.Label, error) {
 		return nil, err
 	}
 	for i := 1; i < len(nodes); i += 2 {
-		labels = append(labels, &prompb.Label{Name: nodes[i], Value: nodes[i+1]})
+		labels = append(labels, &prompb.Label{Name: utils.Unescape(nodes[i]), Value: utils.Unescape(nodes[i+1])})
 	}
 	return labels, nil
 }

--- a/client/graphite/rules_test.go
+++ b/client/graphite/rules_test.go
@@ -181,6 +181,17 @@ func TestMetricLabelsFromPath(t *testing.T) {
 	actualLabels, _ := metricLabelsFromPath(path, prefix, false)
 	require.Equal(t, expectedLabels, actualLabels)
 }
+func TestMetricLabelsFromSpecialPath(t *testing.T) {
+	path := "prometheus-prefix.test.owner.team-Y.interface.Hu0%2F0%2F1%2F3%2E99"
+	prefix := "prometheus-prefix"
+	expectedLabels := []*prompb.Label{
+		&prompb.Label{Name: model.MetricNameLabel, Value: "test"},
+		&prompb.Label{Name: "owner", Value: "team-Y"},
+		&prompb.Label{Name: "interface", Value: "Hu0/0/1/3.99"},
+	}
+	actualLabels, _ := metricLabelsFromPath(path, prefix, true)
+	require.Equal(t, expectedLabels, actualLabels)
+}
 
 func TestReplaceNilLabelTemplatedPathsFromMetric(t *testing.T) {
 	testConfigNilLabelStr := `

--- a/client/graphite/rules_test.go
+++ b/client/graphite/rules_test.go
@@ -178,7 +178,7 @@ func TestMetricLabelsFromPath(t *testing.T) {
 		&prompb.Label{Name: model.MetricNameLabel, Value: "test"},
 		&prompb.Label{Name: "owner", Value: "team-X"},
 	}
-	actualLabels, _ := metricLabelsFromPath(path, prefix, false)
+	actualLabels, _ := metricLabelsFromPath(path, prefix)
 	require.Equal(t, expectedLabels, actualLabels)
 }
 func TestMetricLabelsFromSpecialPath(t *testing.T) {
@@ -189,7 +189,7 @@ func TestMetricLabelsFromSpecialPath(t *testing.T) {
 		&prompb.Label{Name: "owner", Value: "team-Y"},
 		&prompb.Label{Name: "interface", Value: "Hu0/0/1/3.99"},
 	}
-	actualLabels, _ := metricLabelsFromPath(path, prefix, true)
+	actualLabels, _ := metricLabelsFromPath(path, prefix)
 	require.Equal(t, expectedLabels, actualLabels)
 }
 

--- a/client/graphite/rules_test.go
+++ b/client/graphite/rules_test.go
@@ -178,7 +178,7 @@ func TestMetricLabelsFromPath(t *testing.T) {
 		&prompb.Label{Name: model.MetricNameLabel, Value: "test"},
 		&prompb.Label{Name: "owner", Value: "team-X"},
 	}
-	actualLabels, _ := metricLabelsFromPath(path, prefix)
+	actualLabels, _ := metricLabelsFromPath(path, prefix, false)
 	require.Equal(t, expectedLabels, actualLabels)
 }
 

--- a/utils/unescape.go
+++ b/utils/unescape.go
@@ -1,0 +1,44 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"bytes"
+	"net/url"
+	"strings"
+)
+
+// Unescape takes string that have been escape to comply graphite's storage format
+// and return their original value
+func Unescape(tv string) string {
+	// unescape percent encoding
+	new, _ := url.PathUnescape(tv)
+	length := len(new)
+	result := bytes.NewBuffer(make([]byte, 0, length))
+	for i := 0; i < length; i++ {
+		b := new[i]
+		switch {
+		// / could have been double escaped
+		case b == '\\' && i < length-1:
+			n := new[i+1]
+			// if next byte is not a symbol, this / is legitimate
+			if strings.IndexByte(symbols, n) == -1 {
+				result.WriteByte(b)
+			}
+		default:
+			result.WriteByte(b)
+		}
+	}
+	return result.String()
+}

--- a/utils/unescape_test.go
+++ b/utils/unescape_test.go
@@ -1,0 +1,36 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+)
+
+func TestUnescape(t *testing.T) {
+	// Can we correctly keep and unescape valid chars.
+	value := "abzABZ019\\(\\)\\{\\}\\,\\'\\\"\\\\"
+	expected := "abzABZ019(){},'\"\\"
+	actual := Unescape(value)
+	if expected != actual {
+		t.Errorf("Expected %s, got %s", expected, actual)
+	}
+
+	// Test percent-decoding.
+	value = "%C3%A9%2F|_;:%25%2E"
+	expected = "é/|_;:%."
+	actual = Unescape(value)
+	if expected != actual {
+		t.Errorf("Expected %s, got %s", expected, actual)
+	}
+}


### PR DESCRIPTION
As graphite-remote-adapter escapes some characters when writing to Graphite (to comply with storage constraints for example), it needs to unescape when Prometheus wants to read from Graphite.