### PR TITLE
Fix issue #57

### DIFF
--- a/cmd/graphite-remote-adapter/main.go
+++ b/cmd/graphite-remote-adapter/main.go
@@ -47,6 +47,18 @@ func reload(cliCfg *config.Config, logger log.Logger) (*config.Config, error) {
 		return nil, err
 	}
 
+	if cliCfg.Read.Delay == 0 {
+		cfg.Read.Delay = cliCfg.Read.Delay
+	}
+
+	if cliCfg.Read.Timeout == 0 {
+		cfg.Read.Timeout = cliCfg.Read.Timeout
+	}
+
+	if cliCfg.Write.Timeout == 0 {
+		cfg.Write.Timeout = cliCfg.Write.Timeout
+	}
+
 	return cfg, nil
 }
 

--- a/config/cli.go
+++ b/config/cli.go
@@ -32,15 +32,18 @@ func ParseCommandLine() *Config {
 		StringVar(&cfg.Web.TelemetryPath)
 
 	a.Flag("write.timeout",
-		"Maximum duration before timing out remote write requests.").
+		"Maximum duration before timing out remote write requests. Default is 5m").
+		Default(DefaultConfig.Write.Timeout.String()).
 		DurationVar(&cfg.Write.Timeout)
 
 	a.Flag("read.timeout",
-		"Maximum duration before timing out remote read requests.").
+		"Maximum duration before timing out remote read requests. Default is 5m").
+		Default(DefaultConfig.Read.Timeout.String()).
 		DurationVar(&cfg.Read.Timeout)
 
 	a.Flag("read.delay",
-		"Duration ignoring recent samples from all remote read requests.").
+		"Duration ignoring recent samples from all remote read requests. Default is 1h").
+		Default(DefaultConfig.Read.Delay.String()).
 		DurationVar(&cfg.Read.Delay)
 
 	a.Flag("read.ignore-error",


### PR DESCRIPTION
This patch fix issue #57--Can not set --read.delay=0s.
It is because the reload function which in main.go will merge overwritting cliCfg into cfg which is a DefaultConfig.
The merge func recognises  '0s' as an empty value and will not overwite it into cfg. 
As a result, the read.delay will be '1h' which already set in DefaultConfig.
Same problem happens when set 'write.timeout=0s' or 'read.timeout=0s'.