### PR TITLE
Adding "exclude_labels" rule option

### DIFF
--- a/client/graphite/config/config.go
+++ b/client/graphite/config/config.go
@@ -133,10 +133,11 @@ type LabelSetRE map[model.LabelName]Regexp
 // Rule defines a templating rule that customize graphite path using the
 // Tmpl if a metric matching the labels exists.
 type Rule struct {
-	Tmpl     Template   `yaml:"template,omitempty" json:"template,omitempty"`
-	Match    LabelSet   `yaml:"match,omitempty" json:"match,omitempty"`
-	MatchRE  LabelSetRE `yaml:"match_re,omitempty" json:"match_re,omitempty"`
-	Continue bool       `yaml:"continue,omitempty" json:"continue,omitempty"`
+	Tmpl          Template   `yaml:"template,omitempty" json:"template,omitempty"`
+	Match         LabelSet   `yaml:"match,omitempty" json:"match,omitempty"`
+	MatchRE       LabelSetRE `yaml:"match_re,omitempty" json:"match_re,omitempty"`
+	Continue      bool       `yaml:"continue,omitempty" json:"continue,omitempty"`
+	ExcludeLabels bool       `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`

--- a/client/graphite/paths/write_test.go
+++ b/client/graphite/paths/write_test.go
@@ -45,7 +45,10 @@ write:
     continue: false
   - match:
       owner: team-Z
-    continue: false`
+    continue: false
+  - match_re:
+      foo: .+
+    exclude_labels: true`
 
 	testConfig = loadTestConfig(testConfigStr)
 )
@@ -153,6 +156,18 @@ func TestSkipedTemplatedPathsFromMetric(t *testing.T) {
 	t.Log(testConfig.Write.Rules[2])
 	actual, err := pathsFromMetric(skipedMetric, FormatCarbon, "", testConfig.Write.Rules, testConfig.Write.TemplateData)
 	require.Empty(t, actual)
+	require.Empty(t, err)
+}
+
+func TestExcludeLabelFromMetric(t *testing.T) {
+	metricWithFooLabel := model.Metric{
+		model.MetricNameLabel: "test:metric",
+		"foo": "bar",
+	}
+	expected := make([]string, 0)
+	expected = append(expected, "prefix.test:metric")
+	actual, err := pathsFromMetric(metricWithFooLabel, FormatCarbon, "prefix.", testConfig.Write.Rules, testConfig.Write.TemplateData)
+	require.Equal(t, expected, actual)
 	require.Empty(t, err)
 }
 


### PR DESCRIPTION
This new option allows to exclude some labels, for example verbose ones, from the generated Graphite key path