### PR TITLE
Fix: EnableTags=true and FilteredTags="" produces dot separated result

### DIFF
--- a/client/graphite/client.go
+++ b/client/graphite/client.go
@@ -76,7 +76,9 @@ func NewClient(cfg *config.Config, logger log.Logger) *Client {
 			format = paths.Format{Type: paths.FormatCarbonTags}
 		}
 
-		format.FilteredTags = strings.Split(cfg.Graphite.FilteredTags, ",")
+		if cfg.Graphite.FilteredTags != "" {
+			format.FilteredTags = strings.Split(cfg.Graphite.FilteredTags, ",")
+		}
 	}
 
 	return &Client{


### PR DESCRIPTION
Do not split empty string. Otherwise the result is a slice with one element - the empty string. The rest array length checks will consider we have tags to filter.