### PR TITLE
Fix nil pointer exception when cancelling Graphite write request context

### DIFF
--- a/client/graphite/write.go
+++ b/client/graphite/write.go
@@ -115,8 +115,8 @@ func (c *Client) Write(samples model.Samples, r *http.Request, dryRun bool) ([]b
 
 	select {
 	case <-r.Context().Done():
-		return []byte("context cancelled."), fmt.Errorf("request context cancelled while using socket %s <=> %s",
-			c.carbonCon.LocalAddr().String(), c.carbonCon.RemoteAddr().String())
+		return []byte("context cancelled."), fmt.Errorf("request context cancelled while using socket %v <=> %v",
+			c.carbonCon.LocalAddr(), c.carbonCon.RemoteAddr())
 	default:
 	}
 


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xb01428] goroutine 74773 [running]:
github.com/criteo/graphite-remote-adapter/client/graphite.(*Client).Write(0xc000234420, 0xc000247800, 0xa1, 0x100, 0xc0000e6800, 0xc0002a6c00, 0x0, 0x0, 0x0, 0x0, ...)
	/app/client/graphite/write.go:119 +0x548